### PR TITLE
fix: show tax notice before checkout and confirm Stripe final total

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -260,6 +260,10 @@ function CheckoutSuccessContent() {
                     {formatCurrency(orderDetails.amount, orderDetails.currency)}
                   </span>
                 </div>
+
+                <p className="text-xs text-gray-500">
+                  Final total from Stripe — includes taxes and shipping.
+                </p>
               </CardContent>
             </Card>
 

--- a/src/components/pages/Cart.tsx
+++ b/src/components/pages/Cart.tsx
@@ -272,13 +272,22 @@ const Cart = () => {
                           <span>Shipping</span>
                           <span>Calculated at checkout</span>
                         </div>
-                        
+
+                        <div className="flex justify-between text-sm text-gray-600">
+                          <span>Taxes</span>
+                          <span>Applied at checkout</span>
+                        </div>
+
                         <Separator />
-                        
+
                         <div className="flex justify-between text-lg font-semibold" data-testid="total-amount">
-                          <span>Total</span>
+                          <span>Subtotal</span>
                           <span>${cart.subtotal.toFixed(2)}</span>
                         </div>
+
+                        <p className="text-xs text-gray-500">
+                          Final order total — including taxes and shipping — is calculated by Stripe at checkout.
+                        </p>
                         
                         <Link href="/checkout" className="block">
                           <Button 

--- a/src/components/pages/Checkout.tsx
+++ b/src/components/pages/Checkout.tsx
@@ -599,12 +599,23 @@ const CheckoutForm: React.FC = () => {
                 <span>${(item.price * item.quantity).toFixed(2)}</span>
               </div>
             ))}
-            <div className="border-t pt-2 mt-2">
-              <div className="flex justify-between font-semibold">
-                <span>Total</span>
+            <div className="border-t pt-2 mt-2 space-y-1">
+              <div className="flex justify-between text-sm text-gray-600">
+                <span>Shipping</span>
+                <span>Calculated at checkout</span>
+              </div>
+              <div className="flex justify-between text-sm text-gray-600">
+                <span>Taxes</span>
+                <span>Applied at checkout</span>
+              </div>
+              <div className="flex justify-between font-semibold pt-1">
+                <span>Order Total</span>
                 <span data-testid="order-total">${cart.subtotal.toFixed(2)}</span>
               </div>
             </div>
+            <p className="text-xs text-gray-500 mt-2">
+              Taxes and shipping are calculated by Stripe at checkout. Your final total will be shown before payment.
+            </p>
           </div>
 
           {/* Affiliate / Referral Code */}


### PR DESCRIPTION
## What

Users had no warning that taxes are added at checkout. The Cart and Checkout order summaries showed only the subtotal labeled as "Total", which could mislead — the real total (incl. tax + shipping) is computed by Stripe on the hosted checkout page.

## Changes

- **Cart** (`Cart.tsx`): added "Taxes — Applied at checkout" line + note that the final total (incl. taxes & shipping) is calculated by Stripe at checkout. Relabeled `Total` → `Subtotal`.
- **Checkout** (`Checkout.tsx`): added "Shipping — Calculated at checkout" and "Taxes — Applied at checkout" lines above the order total, plus a note that the final total is shown before payment. `order-total` testid preserved.
- **Success** (`success/page.tsx`): the total already uses `amount_total` from Stripe (final, incl. tax + shipping). Added a clarifying hint.

## Notes

- No backend change. `create-checkout-session` already enables Stripe Tax (`automatic_tax.enabled = true`, `tax_behavior: 'exclusive'`), so tax is added on the hosted page.
- UI-only change to 3 files; no other working-tree changes included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Order summary now displays separate line items for subtotal, taxes, and shipping fees
* Checkout and success pages now include clarification text indicating that Stripe calculates and applies taxes and shipping charges at checkout
* Order summary sections have been updated across checkout pages to provide enhanced visibility of the complete pricing breakdown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->